### PR TITLE
**lxml** was written as **lxlm** that was confusing.

### DIFF
--- a/Scrapy.md
+++ b/Scrapy.md
@@ -1,4 +1,4 @@
-In this tutorial, I will write about how to use **Scrapy** to crawl websites. Scrapy internally uses **lxlm**.
+In this tutorial, I will write about how to use **Scrapy** to crawl websites. Scrapy internally uses **lxml**.
 
 I am assuming that scrapy is installed on the system.
 


### PR DESCRIPTION
The lxml XML toolkit is a Pythonic binding for the C libraries libxml2 and libxslt. It is unique in that it combines the speed and XML feature completeness of these libraries with the simplicity of a native Python API, mostly compatible but superior to the well-known ElementTree API. The latest release works with all CPython versions from 2.6 to 3.4. See the introduction for more information about background and goals of the lxml project.
Source: www.lxml.de
